### PR TITLE
Use all hyperblock query params

### DIFF
--- a/api/hyper_block_proxy.go
+++ b/api/hyper_block_proxy.go
@@ -5,23 +5,29 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/ElrondNetwork/covalent-indexer-go/cmd/proxy/config"
 	"github.com/ElrondNetwork/elrond-go/api/shared"
 	"github.com/gin-gonic/gin"
 )
 
 type hyperBlockProxy struct {
 	hyperBlockFacade HyperBlockFacadeHandler
+	options          config.HyperBlockQueryOptions
 }
 
 // NewHyperBlockProxy will create a covalent proxy, able to fetch hyper block requests
 // from Elrond and return them in covalent format
-func NewHyperBlockProxy(hyperBlockFacade HyperBlockFacadeHandler) (*hyperBlockProxy, error) {
+func NewHyperBlockProxy(
+	hyperBlockFacade HyperBlockFacadeHandler,
+	hyperBlockQueryOptions config.HyperBlockQueryOptions,
+) (*hyperBlockProxy, error) {
 	if hyperBlockFacade == nil {
 		return nil, errNilHyperBlockFacade
 	}
 
 	return &hyperBlockProxy{
 		hyperBlockFacade: hyperBlockFacade,
+		options:          hyperBlockQueryOptions,
 	}, nil
 }
 
@@ -33,7 +39,7 @@ func (hbp *hyperBlockProxy) GetHyperBlockByNonce(c *gin.Context) {
 		return
 	}
 
-	hyperBlockApiResponse, err := hbp.hyperBlockFacade.GetHyperBlockByNonce(nonce, options)
+	hyperBlockApiResponse, err := hbp.hyperBlockFacade.GetHyperBlockByNonce(nonce, hbp.options)
 	if err != nil {
 		respondWithInternalError(c, err)
 		return
@@ -59,7 +65,7 @@ func (hbp *hyperBlockProxy) GetHyperBlockByHash(c *gin.Context) {
 		return
 	}
 
-	hyperBlockApiResponse, err := hbp.hyperBlockFacade.GetHyperBlockByHash(hash, options)
+	hyperBlockApiResponse, err := hbp.hyperBlockFacade.GetHyperBlockByHash(hash, hbp.options)
 	if err != nil {
 		respondWithInternalError(c, err)
 		return

--- a/api/hyper_block_proxy_test.go
+++ b/api/hyper_block_proxy_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/ElrondNetwork/covalent-indexer-go/api"
+	"github.com/ElrondNetwork/covalent-indexer-go/cmd/proxy/config"
 	"github.com/ElrondNetwork/covalent-indexer-go/testscommon/mock/apiMocks"
 	"github.com/ElrondNetwork/elrond-go/api/shared"
 	"github.com/gin-gonic/gin"
@@ -59,7 +60,7 @@ func TestNewHyperBlockProxy(t *testing.T) {
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		proxy, err := api.NewHyperBlockProxy(&apiMocks.HyperBlockFacadeStub{})
+		proxy, err := api.NewHyperBlockProxy(&apiMocks.HyperBlockFacadeStub{}, config.HyperBlockQueryOptions{})
 		require.Nil(t, err)
 		require.NotNil(t, proxy)
 	})
@@ -67,7 +68,7 @@ func TestNewHyperBlockProxy(t *testing.T) {
 	t.Run("nil facade, should return error", func(t *testing.T) {
 		t.Parallel()
 
-		proxy, err := api.NewHyperBlockProxy(nil)
+		proxy, err := api.NewHyperBlockProxy(nil, config.HyperBlockQueryOptions{})
 		require.Nil(t, proxy)
 		require.Equal(t, api.ErrNilHyperBlockFacade, err)
 	})
@@ -103,12 +104,12 @@ func TestHyperBlockProxy_GetHyperBlockByNonce(t *testing.T) {
 			Code:  "success",
 		}
 		facade := &apiMocks.HyperBlockFacadeStub{
-			GetHyperBlockByNonceCalled: func(nonce uint64, options api.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
+			GetHyperBlockByNonceCalled: func(nonce uint64, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
 				require.Equal(t, requestedNonce, nonce)
 				return blockResponse, nil
 			},
 		}
-		proxy, _ := api.NewHyperBlockProxy(facade)
+		proxy, _ := api.NewHyperBlockProxy(facade, config.HyperBlockQueryOptions{})
 		ws := startProxyServer(proxy)
 		requestPath := fmt.Sprintf("%s/by-nonce/%d", hyperBlockPath, requestedNonce)
 		apiResp := sendRequest(t, ws, requestPath, http.StatusOK)
@@ -120,12 +121,12 @@ func TestHyperBlockProxy_GetHyperBlockByNonce(t *testing.T) {
 
 		getHyperBlockFromFacadeCalled := false
 		facade := &apiMocks.HyperBlockFacadeStub{
-			GetHyperBlockByNonceCalled: func(nonce uint64, options api.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
+			GetHyperBlockByNonceCalled: func(nonce uint64, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
 				getHyperBlockFromFacadeCalled = true
 				return nil, nil
 			},
 		}
-		proxy, _ := api.NewHyperBlockProxy(facade)
+		proxy, _ := api.NewHyperBlockProxy(facade, config.HyperBlockQueryOptions{})
 		ws := startProxyServer(proxy)
 
 		requestPath := fmt.Sprintf("%s/by-nonce/abc", hyperBlockPath)
@@ -141,11 +142,11 @@ func TestHyperBlockProxy_GetHyperBlockByNonce(t *testing.T) {
 
 		errFacade := errors.New("error getting hyper block from facade")
 		facade := &apiMocks.HyperBlockFacadeStub{
-			GetHyperBlockByNonceCalled: func(nonce uint64, options api.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
+			GetHyperBlockByNonceCalled: func(nonce uint64, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
 				return nil, errFacade
 			},
 		}
-		proxy, _ := api.NewHyperBlockProxy(facade)
+		proxy, _ := api.NewHyperBlockProxy(facade, config.HyperBlockQueryOptions{})
 		ws := startProxyServer(proxy)
 
 		requestPath := fmt.Sprintf("%s/by-nonce/4", hyperBlockPath)
@@ -171,12 +172,12 @@ func TestHyperBlockProxy_GetHyperBlockByHash(t *testing.T) {
 			Code:  "success",
 		}
 		facade := &apiMocks.HyperBlockFacadeStub{
-			GetHyperBlockByHashCalled: func(hash string, options api.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
+			GetHyperBlockByHashCalled: func(hash string, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
 				require.Equal(t, requestedHash, hash)
 				return blockResponse, nil
 			},
 		}
-		proxy, _ := api.NewHyperBlockProxy(facade)
+		proxy, _ := api.NewHyperBlockProxy(facade, config.HyperBlockQueryOptions{})
 		ws := startProxyServer(proxy)
 		requestPath := fmt.Sprintf("%s/by-hash/%s", hyperBlockPath, requestedHash)
 		apiResp := sendRequest(t, ws, requestPath, http.StatusOK)
@@ -188,12 +189,12 @@ func TestHyperBlockProxy_GetHyperBlockByHash(t *testing.T) {
 
 		getHyperBlockFromFacadeCalled := false
 		facade := &apiMocks.HyperBlockFacadeStub{
-			GetHyperBlockByHashCalled: func(hash string, options api.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
+			GetHyperBlockByHashCalled: func(hash string, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
 				getHyperBlockFromFacadeCalled = true
 				return nil, nil
 			},
 		}
-		proxy, _ := api.NewHyperBlockProxy(facade)
+		proxy, _ := api.NewHyperBlockProxy(facade, config.HyperBlockQueryOptions{})
 		ws := startProxyServer(proxy)
 
 		requestPath := fmt.Sprintf("%s/by-hash/zx", hyperBlockPath)
@@ -209,11 +210,11 @@ func TestHyperBlockProxy_GetHyperBlockByHash(t *testing.T) {
 
 		errFacade := errors.New("error getting hyper block from facade")
 		facade := &apiMocks.HyperBlockFacadeStub{
-			GetHyperBlockByHashCalled: func(hash string, options api.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
+			GetHyperBlockByHashCalled: func(hash string, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
 				return nil, errFacade
 			},
 		}
-		proxy, _ := api.NewHyperBlockProxy(facade)
+		proxy, _ := api.NewHyperBlockProxy(facade, config.HyperBlockQueryOptions{})
 		ws := startProxyServer(proxy)
 
 		requestPath := fmt.Sprintf("%s/by-hash/ff", hyperBlockPath)

--- a/api/interface.go
+++ b/api/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/ElrondNetwork/covalent-indexer-go/cmd/proxy/config"
 	"github.com/gin-gonic/gin"
 )
 
@@ -26,8 +27,8 @@ type ElrondHyperBlockEndpointHandler interface {
 
 // HyperBlockFacadeHandler defines the actions needed for fetching of hyperBlocks from Elrond proxy in covalent format
 type HyperBlockFacadeHandler interface {
-	GetHyperBlockByNonce(nonce uint64, options HyperBlockQueryOptions) (*CovalentHyperBlockApiResponse, error)
-	GetHyperBlockByHash(hash string, options HyperBlockQueryOptions) (*CovalentHyperBlockApiResponse, error)
+	GetHyperBlockByNonce(nonce uint64, options config.HyperBlockQueryOptions) (*CovalentHyperBlockApiResponse, error)
+	GetHyperBlockByHash(hash string, options config.HyperBlockQueryOptions) (*CovalentHyperBlockApiResponse, error)
 }
 
 // HyperBlockProxy is the covalent proxy. It should be able to fetch hyper blocks from

--- a/api/options.go
+++ b/api/options.go
@@ -1,22 +1,31 @@
 package api
 
 const (
-	// UrlParameterWithBalances represents the name of an URL parameter to query balances per hyperBlock
-	UrlParameterWithBalances = "withBalances"
 	// UrlParameterWithLogs represents the name of an URL parameter to query logs per hyperBlock
 	UrlParameterWithLogs = "withLogs"
+	// UrlParameterNotarizedAtSource represents the name of an URL parameter to query hyper blocks which are notarized at source
+	UrlParameterNotarizedAtSource = "notarizedAtSource"
+	// UrlParameterWithAlteredAccounts represents the name of an URL parameter to query altered accounts per hyperBlock
+	UrlParameterWithAlteredAccounts = "withAlteredAccounts"
+	// UrlParameterTokens represents the name of an URL parameter to query altered accounts with tokens
+	UrlParameterTokens = "tokens"
+	// UrlParameterWithMetaData represents the name of an URL parameter to query meta data for altered accounts with tokens
+	UrlParameterWithMetaData = "withMetadata"
 )
 
 // HyperBlockQueryOptions holds options for hyperBlock queries
 type HyperBlockQueryOptions struct {
-	WithLogs     bool
-	WithBalances bool
+	WithLogs            bool
+	WithAlteredAccounts bool
+	NotarizedAtSource   bool
+	Tokens              string
+	WithMetaData        bool
 }
 
-// TODO: Remove this once the feat is complete, since:
-// - withLogs is implemented, but not available on mainnet
-// - withBalances is not yet implemented
 var options = HyperBlockQueryOptions{
-	WithLogs:     true,
-	WithBalances: false,
+	WithLogs:            true,
+	WithAlteredAccounts: true,
+	NotarizedAtSource:   true,
+	Tokens:              "all",
+	WithMetaData:        true,
 }

--- a/api/options.go
+++ b/api/options.go
@@ -12,20 +12,3 @@ const (
 	// UrlParameterWithMetaData represents the name of an URL parameter to query meta data for altered accounts with tokens
 	UrlParameterWithMetaData = "withMetadata"
 )
-
-// HyperBlockQueryOptions holds options for hyperBlock queries
-type HyperBlockQueryOptions struct {
-	WithLogs            bool
-	WithAlteredAccounts bool
-	NotarizedAtSource   bool
-	Tokens              string
-	WithMetaData        bool
-}
-
-var options = HyperBlockQueryOptions{
-	WithLogs:            true,
-	WithAlteredAccounts: true,
-	NotarizedAtSource:   true,
-	Tokens:              "all",
-	WithMetaData:        true,
-}

--- a/cmd/proxy/config.toml
+++ b/cmd/proxy/config.toml
@@ -4,7 +4,6 @@ port = 8086
 # API path to get hyperBlock from covalent proxy
 hyperBlockPath = "/hyperBlock"
 
-
 # elrondProxyUrl url used to fetch hyperBlocks from Elrond; e.g.: https://gateway.elrond.com for mainnet
 elrondProxyUrl = "https://gateway.elrond.com"
 

--- a/cmd/proxy/config.toml
+++ b/cmd/proxy/config.toml
@@ -4,6 +4,22 @@ port = 8086
 # API path to get hyperBlock from covalent proxy
 hyperBlockPath = "/hyperBlock"
 
+[hyperBlockQueryOptions]
+    # hyper block query parameter for Elrond proxy to fetch logs
+    withLogs = true
+
+    # hyper block query parameter for Elrond proxy to fetch altered accounts
+    withAlteredAccounts = true
+
+    # hyper block query parameter for Elrond proxy to fetch hyper blocks notarized at source
+    notarizedAtSource = true
+
+    # hyper block query parameter for Elrond proxy to fetch all tokens in altered accounts
+    tokens = "all"
+
+    # hyper block query parameter for Elrond proxy to fetch all tokens meta data in altered accounts
+    withMetaData = true
+
 # elrondProxyUrl url used to fetch hyperBlocks from Elrond; e.g.: https://gateway.elrond.com for mainnet
 elrondProxyUrl = "https://gateway.elrond.com"
 

--- a/cmd/proxy/config.toml
+++ b/cmd/proxy/config.toml
@@ -4,6 +4,13 @@ port = 8086
 # API path to get hyperBlock from covalent proxy
 hyperBlockPath = "/hyperBlock"
 
+# elrondProxyUrl url used to fetch hyperBlocks from Elrond; e.g.: https://gateway.elrond.com for mainnet
+elrondProxyUrl = "https://gateway.elrond.com"
+
+# requestTimeoutSec represents the maximum number of seconds a request can last until throwing an error
+# A Timeout of zero means no timeout.
+requestTimeOutSec = 80
+
 [hyperBlockQueryOptions]
     # hyper block query parameter for Elrond proxy to fetch logs
     withLogs = true
@@ -19,10 +26,3 @@ hyperBlockPath = "/hyperBlock"
 
     # hyper block query parameter for Elrond proxy to fetch all tokens meta data in altered accounts
     withMetaData = true
-
-# elrondProxyUrl url used to fetch hyperBlocks from Elrond; e.g.: https://gateway.elrond.com for mainnet
-elrondProxyUrl = "https://gateway.elrond.com"
-
-# requestTimeoutSec represents the maximum number of seconds a request can last until throwing an error
-# A Timeout of zero means no timeout.
-requestTimeOutSec = 80

--- a/cmd/proxy/config/config.go
+++ b/cmd/proxy/config/config.go
@@ -20,8 +20,8 @@ type HyperBlockQueryOptions struct {
 	WithLogs            bool   `toml:"withLogs"`
 	WithAlteredAccounts bool   `toml:"withLogs"`
 	NotarizedAtSource   bool   `toml:"notarizedAtSource"`
-	Tokens              string `toml:"tokens"`
 	WithMetaData        bool   `toml:"withMetaData"`
+	Tokens              string `toml:"tokens"`
 }
 
 // LoadConfig will load the Config from the provided file

--- a/cmd/proxy/config/config.go
+++ b/cmd/proxy/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	HyperBlockQueryOptions HyperBlockQueryOptions `toml:"hyperBlockQueryOptions"`
 }
 
+// HyperBlockQueryOptions holds the hyper block query params options
 type HyperBlockQueryOptions struct {
 	WithLogs            bool   `toml:"withLogs"`
 	WithAlteredAccounts bool   `toml:"withLogs"`

--- a/cmd/proxy/config/config.go
+++ b/cmd/proxy/config/config.go
@@ -8,10 +8,19 @@ import (
 
 // Config holds the config for covalent proxy
 type Config struct {
-	Port              uint32 `toml:"port"`
-	HyperBlockPath    string `toml:"hyperBlockPath"`
-	ElrondProxyUrl    string `toml:"elrondProxyUrl"`
-	RequestTimeOutSec uint64 `toml:"requestTimeOutSec"`
+	Port                   uint32                 `toml:"port"`
+	HyperBlockPath         string                 `toml:"hyperBlockPath"`
+	ElrondProxyUrl         string                 `toml:"elrondProxyUrl"`
+	RequestTimeOutSec      uint64                 `toml:"requestTimeOutSec"`
+	HyperBlockQueryOptions HyperBlockQueryOptions `toml:"hyperBlockQueryOptions"`
+}
+
+type HyperBlockQueryOptions struct {
+	WithLogs            bool   `toml:"withLogs"`
+	WithAlteredAccounts bool   `toml:"withLogs"`
+	NotarizedAtSource   bool   `toml:"notarizedAtSource"`
+	Tokens              string `toml:"tokens"`
+	WithMetaData        bool   `toml:"withMetaData"`
 }
 
 // LoadConfig will load the Config from the provided file

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -94,7 +94,7 @@ func createServer(cfg *config.Config) (api.HTTPServer, error) {
 		return nil, err
 	}
 
-	hyperBlockProxy, err := api.NewHyperBlockProxy(hyperBlockFacade)
+	hyperBlockProxy, err := api.NewHyperBlockProxy(hyperBlockFacade, cfg.HyperBlockQueryOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/facade/hyper_block_facade.go
+++ b/facade/hyper_block_facade.go
@@ -73,7 +73,10 @@ func buildUrlWithBlockQueryOptions(path string, options api.HyperBlockQueryOptio
 	query := u.Query()
 
 	setQueryParamIfTrue(query, options.WithLogs, api.UrlParameterWithLogs)
-	setQueryParamIfTrue(query, options.WithBalances, api.UrlParameterWithBalances)
+	setQueryParamIfTrue(query, options.NotarizedAtSource, api.UrlParameterNotarizedAtSource)
+	setQueryParamIfTrue(query, options.WithAlteredAccounts, api.UrlParameterWithAlteredAccounts)
+	setQueryParamIfNotEmpty(query, options.Tokens, api.UrlParameterTokens)
+	setQueryParamIfTrue(query, options.WithMetaData, api.UrlParameterWithMetaData)
 
 	u.RawQuery = query.Encode()
 	return u.String()
@@ -82,6 +85,12 @@ func buildUrlWithBlockQueryOptions(path string, options api.HyperBlockQueryOptio
 func setQueryParamIfTrue(query url.Values, option bool, urlParam string) {
 	if option {
 		query.Set(urlParam, "true")
+	}
+}
+
+func setQueryParamIfNotEmpty(query url.Values, option string, urlParam string) {
+	if len(option) > 0 {
+		query.Set(urlParam, option)
 	}
 }
 

--- a/facade/hyper_block_facade.go
+++ b/facade/hyper_block_facade.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ElrondNetwork/covalent-indexer-go"
 	"github.com/ElrondNetwork/covalent-indexer-go/api"
+	"github.com/ElrondNetwork/covalent-indexer-go/cmd/proxy/config"
 	"github.com/ElrondNetwork/elrond-go/api/shared"
 )
 
@@ -48,7 +49,7 @@ func NewHyperBlockFacade(
 }
 
 // GetHyperBlockByNonce will fetch the hyper block from Elrond proxy with provided nonce and options in covalent format
-func (hpf *hyperBlockFacade) GetHyperBlockByNonce(nonce uint64, options api.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
+func (hpf *hyperBlockFacade) GetHyperBlockByNonce(nonce uint64, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
 	blockByNoncePath := fmt.Sprintf("%s/%d", hyperBlockPathByNonce, nonce)
 	fullPath := hpf.getFullPathWithOptions(blockByNoncePath, options)
 
@@ -56,19 +57,19 @@ func (hpf *hyperBlockFacade) GetHyperBlockByNonce(nonce uint64, options api.Hype
 }
 
 // GetHyperBlockByHash will fetch the hyper block from Elrond proxy with provided hash and options in covalent format
-func (hpf *hyperBlockFacade) GetHyperBlockByHash(hash string, options api.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
+func (hpf *hyperBlockFacade) GetHyperBlockByHash(hash string, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
 	blockByHashPath := fmt.Sprintf("%s/%s", hyperBlockPathByHash, hash)
 	fullPath := hpf.getFullPathWithOptions(blockByHashPath, options)
 
 	return hpf.getHyperBlock(fullPath)
 }
 
-func (hpf *hyperBlockFacade) getFullPathWithOptions(path string, options api.HyperBlockQueryOptions) string {
+func (hpf *hyperBlockFacade) getFullPathWithOptions(path string, options config.HyperBlockQueryOptions) string {
 	pathWithOptions := buildUrlWithBlockQueryOptions(path, options)
 	return fmt.Sprintf("%s%s", hpf.elrondProxyUrl, pathWithOptions)
 }
 
-func buildUrlWithBlockQueryOptions(path string, options api.HyperBlockQueryOptions) string {
+func buildUrlWithBlockQueryOptions(path string, options config.HyperBlockQueryOptions) string {
 	u := url.URL{Path: path}
 	query := u.Query()
 

--- a/facade/hyper_block_facade_test.go
+++ b/facade/hyper_block_facade_test.go
@@ -163,28 +163,46 @@ func TestHyperBlockFacade_buildUrlWithBlockQueryOptions(t *testing.T) {
 	path := "path"
 
 	fullPath := buildUrlWithBlockQueryOptions(path, api.HyperBlockQueryOptions{
-		WithLogs:     false,
-		WithBalances: false,
+		WithLogs:            false,
+		WithAlteredAccounts: false,
 	})
 	require.Equal(t, path, fullPath)
 
 	fullPath = buildUrlWithBlockQueryOptions(path, api.HyperBlockQueryOptions{
-		WithLogs:     true,
-		WithBalances: false,
+		WithLogs:            true,
+		WithAlteredAccounts: false,
 	})
 	require.Equal(t, fmt.Sprintf("%s?%s=true", path, api.UrlParameterWithLogs), fullPath)
 
 	fullPath = buildUrlWithBlockQueryOptions(path, api.HyperBlockQueryOptions{
-		WithLogs:     false,
-		WithBalances: true,
+		WithLogs:            false,
+		WithAlteredAccounts: true,
 	})
-	require.Equal(t, fmt.Sprintf("%s?%s=true", path, api.UrlParameterWithBalances), fullPath)
+	require.Equal(t, fmt.Sprintf("%s?%s=true", path, api.UrlParameterWithAlteredAccounts), fullPath)
 
 	fullPath = buildUrlWithBlockQueryOptions(path, api.HyperBlockQueryOptions{
-		WithLogs:     true,
-		WithBalances: true,
+		WithLogs:            true,
+		WithAlteredAccounts: true,
 	})
-	require.Equal(t, fmt.Sprintf("%s?%s=true&%s=true", path, api.UrlParameterWithBalances, api.UrlParameterWithLogs), fullPath)
+	require.Equal(t, fmt.Sprintf("%s?%s=true&%s=true", path, api.UrlParameterWithAlteredAccounts, api.UrlParameterWithLogs), fullPath)
+
+	fullPath = buildUrlWithBlockQueryOptions(path, api.HyperBlockQueryOptions{
+		WithLogs:            true,
+		WithAlteredAccounts: true,
+		Tokens:              "all",
+		WithMetaData:        true,
+		NotarizedAtSource:   true,
+	})
+	require.Equal(t,
+		fmt.Sprintf("%s?%s=true&%s=all&%s=true&%s=true&%s=true",
+			path,
+			api.UrlParameterNotarizedAtSource,
+			api.UrlParameterTokens,
+			api.UrlParameterWithAlteredAccounts,
+			api.UrlParameterWithLogs,
+			api.UrlParameterWithMetaData,
+		),
+		fullPath)
 }
 
 func TestHyperBlockFacade_GetHyperBlock_ErrorCases(t *testing.T) {

--- a/facade/hyper_block_facade_test.go
+++ b/facade/hyper_block_facade_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ElrondNetwork/covalent-indexer-go/api"
+	"github.com/ElrondNetwork/covalent-indexer-go/cmd/proxy/config"
 	"github.com/ElrondNetwork/covalent-indexer-go/hyperBlock"
 	"github.com/ElrondNetwork/covalent-indexer-go/schema"
 	"github.com/ElrondNetwork/covalent-indexer-go/testscommon/mock"
@@ -99,7 +100,7 @@ func TestHyperBlockFacade_GetHyperBlockByNonce(t *testing.T) {
 
 	facade, _ := NewHyperBlockFacade(elrondProxyUrl, encoder, elrondEndPoint, processor)
 
-	block, err := facade.GetHyperBlockByNonce(4, api.HyperBlockQueryOptions{})
+	block, err := facade.GetHyperBlockByNonce(4, config.HyperBlockQueryOptions{})
 	require.Nil(t, err)
 	require.Equal(t, &api.CovalentHyperBlockApiResponse{
 		Data:  encodedBlock,
@@ -148,7 +149,7 @@ func TestHyperBlockFacade_GetHyperBlockByHash(t *testing.T) {
 
 	facade, _ := NewHyperBlockFacade(elrondProxyUrl, encoder, elrondEndPoint, processor)
 
-	block, err := facade.GetHyperBlockByHash(requestedHash, api.HyperBlockQueryOptions{})
+	block, err := facade.GetHyperBlockByHash(requestedHash, config.HyperBlockQueryOptions{})
 	require.Nil(t, err)
 	require.Equal(t, &api.CovalentHyperBlockApiResponse{
 		Data:  encodedBlock,
@@ -162,31 +163,31 @@ func TestHyperBlockFacade_buildUrlWithBlockQueryOptions(t *testing.T) {
 
 	path := "path"
 
-	fullPath := buildUrlWithBlockQueryOptions(path, api.HyperBlockQueryOptions{
+	fullPath := buildUrlWithBlockQueryOptions(path, config.HyperBlockQueryOptions{
 		WithLogs:            false,
 		WithAlteredAccounts: false,
 	})
 	require.Equal(t, path, fullPath)
 
-	fullPath = buildUrlWithBlockQueryOptions(path, api.HyperBlockQueryOptions{
+	fullPath = buildUrlWithBlockQueryOptions(path, config.HyperBlockQueryOptions{
 		WithLogs:            true,
 		WithAlteredAccounts: false,
 	})
 	require.Equal(t, fmt.Sprintf("%s?%s=true", path, api.UrlParameterWithLogs), fullPath)
 
-	fullPath = buildUrlWithBlockQueryOptions(path, api.HyperBlockQueryOptions{
+	fullPath = buildUrlWithBlockQueryOptions(path, config.HyperBlockQueryOptions{
 		WithLogs:            false,
 		WithAlteredAccounts: true,
 	})
 	require.Equal(t, fmt.Sprintf("%s?%s=true", path, api.UrlParameterWithAlteredAccounts), fullPath)
 
-	fullPath = buildUrlWithBlockQueryOptions(path, api.HyperBlockQueryOptions{
+	fullPath = buildUrlWithBlockQueryOptions(path, config.HyperBlockQueryOptions{
 		WithLogs:            true,
 		WithAlteredAccounts: true,
 	})
 	require.Equal(t, fmt.Sprintf("%s?%s=true&%s=true", path, api.UrlParameterWithAlteredAccounts, api.UrlParameterWithLogs), fullPath)
 
-	fullPath = buildUrlWithBlockQueryOptions(path, api.HyperBlockQueryOptions{
+	fullPath = buildUrlWithBlockQueryOptions(path, config.HyperBlockQueryOptions{
 		WithLogs:            true,
 		WithAlteredAccounts: true,
 		Tokens:              "all",

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/ElrondNetwork/covalent-indexer-go
 go 1.16
 
 require (
-	github.com/ElrondNetwork/elrond-go v1.3.49-0.20221101105926-2f349fe6063c
-	github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221101091159-7dd46b891266
+	github.com/ElrondNetwork/elrond-go v1.3.49-0.20221108130914-1a14b4940419
+	github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221108113024-38dd797ed574
 	github.com/ElrondNetwork/elrond-go-logger v1.0.9
 	github.com/elodina/go-avro v0.0.0-20160406082632-0c8185d9a3ba
 	github.com/gin-gonic/gin v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -47,9 +47,9 @@ github.com/ElrondNetwork/big-int-util v0.1.0/go.mod h1:96viBvoTXLjZOhEvE0D+QnAwg
 github.com/ElrondNetwork/concurrent-map v0.1.3 h1:j2LtPrNJuerannC1cQDE79STvi/P04gd61sNYo04Zf0=
 github.com/ElrondNetwork/concurrent-map v0.1.3/go.mod h1:3XwSwn4JHI0lrKxWLZvtp53Emr8BXYTmNQGwcukHJEE=
 github.com/ElrondNetwork/covalent-indexer-go v1.0.7-0.20220922092743-7f3a26b4001a/go.mod h1:JvcH6f+nhhJakiCsg++uyJbp9C9HYKB1fulliw+DiA0=
-github.com/ElrondNetwork/elastic-indexer-go v1.2.45-0.20221031092244-8d8cfb7e65bf/go.mod h1:icRk6DOPLTeOtywgXvvtLduqQAnp2Uh3bbtDCOoScQI=
-github.com/ElrondNetwork/elrond-go v1.3.49-0.20221101105926-2f349fe6063c h1:EQFZrGvn7r/hNOn7cdK7he2H3QVMNsKYX56TqrLx5k4=
-github.com/ElrondNetwork/elrond-go v1.3.49-0.20221101105926-2f349fe6063c/go.mod h1:Ki+kGMPV66AIS57d0sFASS4+gUp7aIFE4fTvPRPPmjA=
+github.com/ElrondNetwork/elastic-indexer-go v1.2.46-0.20221108125017-840d49566319/go.mod h1:WFQu99OvIrIeDtNmSxSOxaoV7WoCWGkSas0M6KF/NbA=
+github.com/ElrondNetwork/elrond-go v1.3.49-0.20221108130914-1a14b4940419 h1:lo0icVh5vpWvyLkl+J5PRwqiSA+fFWL7uYzT4c7IC5Y=
+github.com/ElrondNetwork/elrond-go v1.3.49-0.20221108130914-1a14b4940419/go.mod h1:5ytFAbakk3nBrdNjzXqbaUAtGoBUyH/5cqwOc7cHn+A=
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
 github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-core v1.1.13/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
@@ -57,9 +57,8 @@ github.com/ElrondNetwork/elrond-go-core v1.1.18/go.mod h1:Yz8JK5sGBctw7+gU8j2mZH
 github.com/ElrondNetwork/elrond-go-core v1.1.19-0.20220729074346-fca5b87ec7c7/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-core v1.1.19/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-core v1.1.20-0.20220915145036-720d0233becd/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
-github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221028092924-4f1c38bae5f9/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
-github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221101091159-7dd46b891266 h1:PEU7GFJtRXeXnnRumf79wSP9HM6d6LzFHPawe1vWXu8=
-github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221101091159-7dd46b891266/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
+github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221108113024-38dd797ed574 h1:XCj1Fo6Xl8EzAFhaIFcCY393Cu2HPppAKeOdxMaTFT4=
+github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221108113024-38dd797ed574/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.0/go.mod h1:DGiR7/j1xv729Xg8SsjYaUzWXL5svMd44REXjWS/gAc=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.1 h1:5wWCBEZp5SMFO2+Nal8UaJNJcG9G9J4PHNNZvQpEeUE=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.1/go.mod h1:UNmpDaJjLTKxfzUcwua2R7Mh9bicw/L3ICJt5V7zqMo=

--- a/process/accounts/altered_accounts_processor.go
+++ b/process/accounts/altered_accounts_processor.go
@@ -3,7 +3,6 @@ package accounts
 import (
 	"github.com/ElrondNetwork/covalent-indexer-go/process/utility"
 	"github.com/ElrondNetwork/covalent-indexer-go/schema"
-	"github.com/ElrondNetwork/elrond-go-core/data/esdt"
 	"github.com/ElrondNetwork/elrond-go-core/data/outport"
 )
 
@@ -72,7 +71,7 @@ func processAccountsTokenData(apiTokens []*outport.AccountTokenData) ([]*schema.
 	return tokens, nil
 }
 
-func processMetaData(apiMetaData *esdt.MetaData) *schema.MetaData {
+func processMetaData(apiMetaData *outport.TokenMetaData) *schema.MetaData {
 	if apiMetaData == nil {
 		return nil
 	}
@@ -80,7 +79,7 @@ func processMetaData(apiMetaData *esdt.MetaData) *schema.MetaData {
 	return &schema.MetaData{
 		Nonce:      int64(apiMetaData.Nonce),
 		Name:       apiMetaData.Name,
-		Creator:    apiMetaData.Creator,
+		Creator:    []byte(apiMetaData.Creator),
 		Royalties:  int32(apiMetaData.Royalties),
 		Hash:       apiMetaData.Hash,
 		URIs:       apiMetaData.URIs,

--- a/process/accounts/altered_accounts_processor_test.go
+++ b/process/accounts/altered_accounts_processor_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ElrondNetwork/covalent-indexer-go/process/accounts"
 	"github.com/ElrondNetwork/covalent-indexer-go/schema"
-	"github.com/ElrondNetwork/elrond-go-core/data/esdt"
 	"github.com/ElrondNetwork/elrond-go-core/data/outport"
 	"github.com/stretchr/testify/require"
 )
@@ -50,10 +49,10 @@ func createAlteredAccounts() []*outport.AlteredAccount {
 				Identifier: "identifier3",
 				Balance:    "555",
 				Properties: "properties3",
-				MetaData: &esdt.MetaData{
+				MetaData: &outport.TokenMetaData{
 					Nonce:      6,
-					Name:       []byte("name"),
-					Creator:    []byte("creator"),
+					Name:       "name",
+					Creator:    "creator",
 					Royalties:  666,
 					Hash:       []byte("hash"),
 					URIs:       [][]byte{[]byte("uri1"), []byte("uri2")},
@@ -110,7 +109,7 @@ func TestAlteredAccountsProcessor_ProcessAccounts(t *testing.T) {
 				Properties: "properties3",
 				MetaData: &schema.MetaData{
 					Nonce:      6,
-					Name:       []byte("name"),
+					Name:       "name",
 					Creator:    []byte("creator"),
 					Royalties:  666,
 					Hash:       []byte("hash"),

--- a/schema/block.elrond.avsc
+++ b/schema/block.elrond.avsc
@@ -130,7 +130,7 @@
                         {"name": "Name", "type": "bytes"},
                         {"name": "Creator", "type": "bytes"},
                         {"name": "Royalties", "type": "int"},
-                        {"name": "Hash", "type": "hash"},
+                        {"name": "Hash", "type": "bytes"},
                         {"name": "URIs", "type": {"type": "array", "items": "bytes"}},
                         {"name": "Attributes", "type": "bytes"}
                       ]

--- a/schema/block.elrond.avsc
+++ b/schema/block.elrond.avsc
@@ -127,8 +127,8 @@
                       "type": "record",
                       "fields": [
                         {"name": "Nonce", "type": "long"},
-                        {"name": "Name", "type": "bytes"},
-                        {"name": "Creator", "type": "bytes"},
+                        {"name": "Name", "type": "string"},
+                        {"name": "Creator", "type": "address"},
                         {"name": "Royalties", "type": "int"},
                         {"name": "Hash", "type": "bytes"},
                         {"name": "URIs", "type": {"type": "array", "items": "bytes"}},

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -147,7 +147,7 @@ func NewMetaData() *MetaData {
 	return &MetaData{
 		Name:       []byte{},
 		Creator:    []byte{},
-		Hash:       make([]byte, 32),
+		Hash:       []byte{},
 		URIs:       make([][]byte, 0),
 		Attributes: []byte{},
 	}
@@ -570,11 +570,7 @@ var _HyperBlock_schema, _HyperBlock_schema_err = avro.ParseSchema(`{
                                                                                 },
                                                                                 {
                                                                                     "name": "Hash",
-                                                                                    "type": {
-                                                                                        "type": "fixed",
-                                                                                        "size": 32,
-                                                                                        "name": "hash"
-                                                                                    }
+                                                                                    "type": "bytes"
                                                                                 },
                                                                                 {
                                                                                     "name": "URIs",
@@ -1215,11 +1211,7 @@ var _ShardBlocks_schema, _ShardBlocks_schema_err = avro.ParseSchema(`{
                                                             },
                                                             {
                                                                 "name": "Hash",
-                                                                "type": {
-                                                                    "type": "fixed",
-                                                                    "size": 32,
-                                                                    "name": "hash"
-                                                                }
+                                                                "type": "bytes"
                                                             },
                                                             {
                                                                 "name": "URIs",
@@ -1323,11 +1315,7 @@ var _AccountBalanceUpdate_schema, _AccountBalanceUpdate_schema_err = avro.ParseS
                                             },
                                             {
                                                 "name": "Hash",
-                                                "type": {
-                                                    "type": "fixed",
-                                                    "size": 32,
-                                                    "name": "hash"
-                                                }
+                                                "type": "bytes"
                                             },
                                             {
                                                 "name": "URIs",
@@ -1400,11 +1388,7 @@ var _AccountTokenData_schema, _AccountTokenData_schema_err = avro.ParseSchema(`{
                         },
                         {
                             "name": "Hash",
-                            "type": {
-                                "type": "fixed",
-                                "size": 32,
-                                "name": "hash"
-                            }
+                            "type": "bytes"
                         },
                         {
                             "name": "URIs",
@@ -1447,11 +1431,7 @@ var _MetaData_schema, _MetaData_schema_err = avro.ParseSchema(`{
         },
         {
             "name": "Hash",
-            "type": {
-                "type": "fixed",
-                "size": 32,
-                "name": "hash"
-            }
+            "type": "bytes"
         },
         {
             "name": "URIs",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -135,7 +135,7 @@ func (o *AccountTokenData) Schema() avro.Schema {
 
 type MetaData struct {
 	Nonce      int64
-	Name       []byte
+	Name       string
 	Creator    []byte
 	Royalties  int32
 	Hash       []byte
@@ -145,8 +145,7 @@ type MetaData struct {
 
 func NewMetaData() *MetaData {
 	return &MetaData{
-		Name:       []byte{},
-		Creator:    []byte{},
+		Creator:    make([]byte, 62),
 		Hash:       []byte{},
 		URIs:       make([][]byte, 0),
 		Attributes: []byte{},
@@ -558,11 +557,15 @@ var _HyperBlock_schema, _HyperBlock_schema_err = avro.ParseSchema(`{
                                                                                 },
                                                                                 {
                                                                                     "name": "Name",
-                                                                                    "type": "bytes"
+                                                                                    "type": "string"
                                                                                 },
                                                                                 {
                                                                                     "name": "Creator",
-                                                                                    "type": "bytes"
+                                                                                    "type": {
+                                                                                        "type": "fixed",
+                                                                                        "size": 62,
+                                                                                        "name": "address"
+                                                                                    }
                                                                                 },
                                                                                 {
                                                                                     "name": "Royalties",
@@ -1199,11 +1202,15 @@ var _ShardBlocks_schema, _ShardBlocks_schema_err = avro.ParseSchema(`{
                                                             },
                                                             {
                                                                 "name": "Name",
-                                                                "type": "bytes"
+                                                                "type": "string"
                                                             },
                                                             {
                                                                 "name": "Creator",
-                                                                "type": "bytes"
+                                                                "type": {
+                                                                    "type": "fixed",
+                                                                    "size": 62,
+                                                                    "name": "address"
+                                                                }
                                                             },
                                                             {
                                                                 "name": "Royalties",
@@ -1303,11 +1310,15 @@ var _AccountBalanceUpdate_schema, _AccountBalanceUpdate_schema_err = avro.ParseS
                                             },
                                             {
                                                 "name": "Name",
-                                                "type": "bytes"
+                                                "type": "string"
                                             },
                                             {
                                                 "name": "Creator",
-                                                "type": "bytes"
+                                                "type": {
+                                                    "type": "fixed",
+                                                    "size": 62,
+                                                    "name": "address"
+                                                }
                                             },
                                             {
                                                 "name": "Royalties",
@@ -1376,11 +1387,15 @@ var _AccountTokenData_schema, _AccountTokenData_schema_err = avro.ParseSchema(`{
                         },
                         {
                             "name": "Name",
-                            "type": "bytes"
+                            "type": "string"
                         },
                         {
                             "name": "Creator",
-                            "type": "bytes"
+                            "type": {
+                                "type": "fixed",
+                                "size": 62,
+                                "name": "address"
+                            }
                         },
                         {
                             "name": "Royalties",
@@ -1419,11 +1434,15 @@ var _MetaData_schema, _MetaData_schema_err = avro.ParseSchema(`{
         },
         {
             "name": "Name",
-            "type": "bytes"
+            "type": "string"
         },
         {
             "name": "Creator",
-            "type": "bytes"
+            "type": {
+                "type": "fixed",
+                "size": 62,
+                "name": "address"
+            }
         },
         {
             "name": "Royalties",

--- a/testscommon/mock/apiMocks/hyper_block_facade_stub.go
+++ b/testscommon/mock/apiMocks/hyper_block_facade_stub.go
@@ -1,15 +1,18 @@
 package apiMocks
 
-import "github.com/ElrondNetwork/covalent-indexer-go/api"
+import (
+	"github.com/ElrondNetwork/covalent-indexer-go/api"
+	"github.com/ElrondNetwork/covalent-indexer-go/cmd/proxy/config"
+)
 
 // HyperBlockFacadeStub -
 type HyperBlockFacadeStub struct {
-	GetHyperBlockByNonceCalled func(nonce uint64, options api.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error)
-	GetHyperBlockByHashCalled  func(hash string, options api.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error)
+	GetHyperBlockByNonceCalled func(nonce uint64, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error)
+	GetHyperBlockByHashCalled  func(hash string, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error)
 }
 
 // GetHyperBlockByNonce -
-func (hbf *HyperBlockFacadeStub) GetHyperBlockByNonce(nonce uint64, options api.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
+func (hbf *HyperBlockFacadeStub) GetHyperBlockByNonce(nonce uint64, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
 	if hbf.GetHyperBlockByNonceCalled != nil {
 		return hbf.GetHyperBlockByNonceCalled(nonce, options)
 	}
@@ -18,7 +21,7 @@ func (hbf *HyperBlockFacadeStub) GetHyperBlockByNonce(nonce uint64, options api.
 }
 
 // GetHyperBlockByHash -
-func (hbf *HyperBlockFacadeStub) GetHyperBlockByHash(hash string, options api.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
+func (hbf *HyperBlockFacadeStub) GetHyperBlockByHash(hash string, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
 	if hbf.GetHyperBlockByHashCalled != nil {
 		return hbf.GetHyperBlockByHashCalled(hash, options)
 	}


### PR DESCRIPTION
- Added several hyper block query params which have been added meanwhile:
```
type HyperBlockQueryOptions struct {
	WithAlteredAccounts bool   `toml:"withLogs"`
	NotarizedAtSource   bool   `toml:"notarizedAtSource"`
	Tokens              string `toml:"tokens"`
	WithMetaData        bool   `toml:"withMetaData"`
}
```
- Moved all query params in `config.toml`. Proxy will load them and use them for each query
- Changed `Hash` field from `MetaData` to be `bytes` instead of `fixed` size, since it can have any length.