### PR TITLE
Remove metaData

### DIFF
--- a/api/options.go
+++ b/api/options.go
@@ -9,6 +9,4 @@ const (
 	UrlParameterWithAlteredAccounts = "withAlteredAccounts"
 	// UrlParameterTokens represents the name of an URL parameter to query altered accounts with tokens
 	UrlParameterTokens = "tokens"
-	// UrlParameterWithMetaData represents the name of an URL parameter to query meta data for altered accounts with tokens
-	UrlParameterWithMetaData = "withMetadata"
 )

--- a/cmd/proxy/config.toml
+++ b/cmd/proxy/config.toml
@@ -23,6 +23,3 @@ requestTimeOutSec = 80
 
     # hyper block query parameter for Elrond proxy to fetch all tokens in altered accounts
     tokens = "all"
-
-    # hyper block query parameter for Elrond proxy to fetch all tokens meta data in altered accounts
-    withMetaData = true

--- a/cmd/proxy/config/config.go
+++ b/cmd/proxy/config/config.go
@@ -20,7 +20,6 @@ type HyperBlockQueryOptions struct {
 	WithLogs            bool   `toml:"withLogs"`
 	WithAlteredAccounts bool   `toml:"withLogs"`
 	NotarizedAtSource   bool   `toml:"notarizedAtSource"`
-	WithMetaData        bool   `toml:"withMetaData"`
 	Tokens              string `toml:"tokens"`
 }
 

--- a/facade/hyper_block_facade.go
+++ b/facade/hyper_block_facade.go
@@ -76,7 +76,6 @@ func buildUrlWithBlockQueryOptions(path string, options config.HyperBlockQueryOp
 	setQueryParamIfTrue(query, options.NotarizedAtSource, api.UrlParameterNotarizedAtSource)
 	setQueryParamIfTrue(query, options.WithAlteredAccounts, api.UrlParameterWithAlteredAccounts)
 	setQueryParamIfNotEmpty(query, options.Tokens, api.UrlParameterTokens)
-	setQueryParamIfTrue(query, options.WithMetaData, api.UrlParameterWithMetaData)
 
 	u.RawQuery = query.Encode()
 	return u.String()

--- a/facade/hyper_block_facade_test.go
+++ b/facade/hyper_block_facade_test.go
@@ -190,17 +190,15 @@ func TestHyperBlockFacade_buildUrlWithBlockQueryOptions(t *testing.T) {
 		WithLogs:            true,
 		WithAlteredAccounts: true,
 		Tokens:              "all",
-		WithMetaData:        true,
 		NotarizedAtSource:   true,
 	})
 	require.Equal(t,
-		fmt.Sprintf("%s?%s=true&%s=all&%s=true&%s=true&%s=true",
+		fmt.Sprintf("%s?%s=true&%s=all&%s=true&%s=true",
 			path,
 			api.UrlParameterNotarizedAtSource,
 			api.UrlParameterTokens,
 			api.UrlParameterWithAlteredAccounts,
 			api.UrlParameterWithLogs,
-			api.UrlParameterWithMetaData,
 		),
 		fullPath)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ElrondNetwork/covalent-indexer-go
 go 1.16
 
 require (
-	github.com/ElrondNetwork/elrond-go-core v1.1.24
+	github.com/ElrondNetwork/elrond-go-core v1.1.25
 	github.com/ElrondNetwork/elrond-go-logger v1.0.9
 	github.com/elodina/go-avro v0.0.0-20160406082632-0c8185d9a3ba
 	github.com/gin-gonic/gin v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/ElrondNetwork/elrond-go-core v1.1.24
 	github.com/ElrondNetwork/elrond-go-logger v1.0.9
-	github.com/elodina/go-avro v0.0.0-20150904081821-bc650d5fd58f
+	github.com/elodina/go-avro v0.0.0-20160406082632-0c8185d9a3ba
 	github.com/gin-gonic/gin v1.8.1
 	github.com/pelletier/go-toml v1.9.3
 	github.com/stretchr/testify v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
 github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
-github.com/elodina/go-avro v0.0.0-20150904081821-bc650d5fd58f h1:xDci7eiIQe66xPEBHy+ljOBrMb3b4PmheOKjFyimguI=
-github.com/elodina/go-avro v0.0.0-20150904081821-bc650d5fd58f/go.mod h1:3A7SOsr8WBIpkWUsqzMpR3tIQbanKqxZcis2GSl12Nk=
+github.com/elodina/go-avro v0.0.0-20160406082632-0c8185d9a3ba h1:QkK2L3uvEaZJ40iFZbiMKz/yQF/MI2uaNO2iyV/ve6w=
+github.com/elodina/go-avro v0.0.0-20160406082632-0c8185d9a3ba/go.mod h1:3A7SOsr8WBIpkWUsqzMpR3tIQbanKqxZcis2GSl12Nk=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
-github.com/ElrondNetwork/elrond-go-core v1.1.24 h1:jamx50C1dP50uwh11EXT0+4pq0E0G3YYTK2xKEewDEk=
-github.com/ElrondNetwork/elrond-go-core v1.1.24/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
+github.com/ElrondNetwork/elrond-go-core v1.1.25 h1:jfO2TsV161bPMLbocjdNR+iy0lNKpfYwA4t5lNAFoK8=
+github.com/ElrondNetwork/elrond-go-core v1.1.25/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
 github.com/ElrondNetwork/elrond-go-logger v1.0.4/go.mod h1:e5D+c97lKUfFdAzFX7rrI2Igl/z4Y0RkKYKWyzprTGk=
 github.com/ElrondNetwork/elrond-go-logger v1.0.9 h1:RByDnVHgSN4zy3bwmvQarsnCd/gDmZ+zwVI+b6i4Plc=
 github.com/ElrondNetwork/elrond-go-logger v1.0.9/go.mod h1:86lz/Y9D1sMAZiukCYxCsETLl1zuI23qj37ct3KUT6A=

--- a/process/accounts/altered_accounts_processor.go
+++ b/process/accounts/altered_accounts_processor.go
@@ -62,29 +62,12 @@ func processAccountsTokenData(apiTokens []*outport.AccountTokenData) ([]*schema.
 			Identifier: apiToken.Identifier,
 			Balance:    balance,
 			Properties: apiToken.Properties,
-			MetaData:   processMetaData(apiToken.MetaData),
 		}
 
 		tokens = append(tokens, token)
 	}
 
 	return tokens, nil
-}
-
-func processMetaData(apiMetaData *outport.TokenMetaData) *schema.MetaData {
-	if apiMetaData == nil {
-		return nil
-	}
-
-	return &schema.MetaData{
-		Nonce:      int64(apiMetaData.Nonce),
-		Name:       apiMetaData.Name,
-		Creator:    []byte(apiMetaData.Creator),
-		Royalties:  int32(apiMetaData.Royalties),
-		Hash:       apiMetaData.Hash,
-		URIs:       apiMetaData.URIs,
-		Attributes: apiMetaData.Attributes,
-	}
 }
 
 func tokensOrNil(accounts []*schema.AccountTokenData) []*schema.AccountTokenData {

--- a/process/accounts/altered_accounts_processor_test.go
+++ b/process/accounts/altered_accounts_processor_test.go
@@ -28,14 +28,12 @@ func createAlteredAccounts() []*outport.AlteredAccount {
 				Identifier: "identifier1",
 				Balance:    "111",
 				Properties: "properties1",
-				MetaData:   nil,
 			},
 			{
 				Nonce:      2,
 				Identifier: "identifier2",
 				Balance:    "222",
 				Properties: "properties2",
-				MetaData:   nil,
 			},
 		},
 	}
@@ -49,15 +47,6 @@ func createAlteredAccounts() []*outport.AlteredAccount {
 				Identifier: "identifier3",
 				Balance:    "555",
 				Properties: "properties3",
-				MetaData: &outport.TokenMetaData{
-					Nonce:      6,
-					Name:       "name",
-					Creator:    "creator",
-					Royalties:  666,
-					Hash:       []byte("hash"),
-					URIs:       [][]byte{[]byte("uri1"), []byte("uri2")},
-					Attributes: []byte("attributes"),
-				},
 			},
 		},
 	}
@@ -86,14 +75,12 @@ func TestAlteredAccountsProcessor_ProcessAccounts(t *testing.T) {
 				Identifier: "identifier1",
 				Balance:    big.NewInt(111).Bytes(),
 				Properties: "properties1",
-				MetaData:   nil,
 			},
 			{
 				Nonce:      2,
 				Identifier: "identifier2",
 				Balance:    big.NewInt(222).Bytes(),
 				Properties: "properties2",
-				MetaData:   nil,
 			},
 		},
 	}
@@ -107,15 +94,6 @@ func TestAlteredAccountsProcessor_ProcessAccounts(t *testing.T) {
 				Identifier: "identifier3",
 				Balance:    big.NewInt(555).Bytes(),
 				Properties: "properties3",
-				MetaData: &schema.MetaData{
-					Nonce:      6,
-					Name:       "name",
-					Creator:    []byte("creator"),
-					Royalties:  666,
-					Hash:       []byte("hash"),
-					URIs:       [][]byte{[]byte("uri1"), []byte("uri2")},
-					Attributes: []byte("attributes"),
-				},
 			},
 		},
 	}

--- a/schema/block.elrond.avsc
+++ b/schema/block.elrond.avsc
@@ -120,21 +120,7 @@
                       "precision": 1000,
                       "scale": 0
                     }},
-                    {"name" : "Properties", "type" :  "string"},
-
-                    {"name": "MetaData", "type": ["null", {
-                      "name": "MetaData",
-                      "type": "record",
-                      "fields": [
-                        {"name": "Nonce", "type": "long"},
-                        {"name": "Name", "type": "string"},
-                        {"name": "Creator", "type": "address"},
-                        {"name": "Royalties", "type": "int"},
-                        {"name": "Hash", "type": "bytes"},
-                        {"name": "URIs", "type": {"type": "array", "items": "bytes"}},
-                        {"name": "Attributes", "type": "bytes"}
-                      ]
-                    }]}
+                    {"name" : "Properties", "type" :  "string"}
                   ]
                 }}
               ]}}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -117,7 +117,6 @@ type AccountTokenData struct {
 	Identifier string
 	Balance    []byte
 	Properties string
-	MetaData   *MetaData
 }
 
 func NewAccountTokenData() *AccountTokenData {
@@ -131,32 +130,6 @@ func (o *AccountTokenData) Schema() avro.Schema {
 		panic(_AccountTokenData_schema_err)
 	}
 	return _AccountTokenData_schema
-}
-
-type MetaData struct {
-	Nonce      int64
-	Name       string
-	Creator    []byte
-	Royalties  int32
-	Hash       []byte
-	URIs       [][]byte
-	Attributes []byte
-}
-
-func NewMetaData() *MetaData {
-	return &MetaData{
-		Creator:    make([]byte, 62),
-		Hash:       []byte{},
-		URIs:       make([][]byte, 0),
-		Attributes: []byte{},
-	}
-}
-
-func (o *MetaData) Schema() avro.Schema {
-	if _MetaData_schema_err != nil {
-		panic(_MetaData_schema_err)
-	}
-	return _MetaData_schema
 }
 
 type Transaction struct {
@@ -541,54 +514,6 @@ var _HyperBlock_schema, _HyperBlock_schema_err = avro.ParseSchema(`{
                                                                 {
                                                                     "name": "Properties",
                                                                     "type": "string"
-                                                                },
-                                                                {
-                                                                    "name": "MetaData",
-                                                                    "default": null,
-                                                                    "type": [
-                                                                        "null",
-                                                                        {
-                                                                            "type": "record",
-                                                                            "name": "MetaData",
-                                                                            "fields": [
-                                                                                {
-                                                                                    "name": "Nonce",
-                                                                                    "type": "long"
-                                                                                },
-                                                                                {
-                                                                                    "name": "Name",
-                                                                                    "type": "string"
-                                                                                },
-                                                                                {
-                                                                                    "name": "Creator",
-                                                                                    "type": {
-                                                                                        "type": "fixed",
-                                                                                        "size": 62,
-                                                                                        "name": "address"
-                                                                                    }
-                                                                                },
-                                                                                {
-                                                                                    "name": "Royalties",
-                                                                                    "type": "int"
-                                                                                },
-                                                                                {
-                                                                                    "name": "Hash",
-                                                                                    "type": "bytes"
-                                                                                },
-                                                                                {
-                                                                                    "name": "URIs",
-                                                                                    "type": {
-                                                                                        "type": "array",
-                                                                                        "items": "bytes"
-                                                                                    }
-                                                                                },
-                                                                                {
-                                                                                    "name": "Attributes",
-                                                                                    "type": "bytes"
-                                                                                }
-                                                                            ]
-                                                                        }
-                                                                    ]
                                                                 }
                                                             ]
                                                         }
@@ -1186,54 +1111,6 @@ var _ShardBlocks_schema, _ShardBlocks_schema_err = avro.ParseSchema(`{
                                             {
                                                 "name": "Properties",
                                                 "type": "string"
-                                            },
-                                            {
-                                                "name": "MetaData",
-                                                "default": null,
-                                                "type": [
-                                                    "null",
-                                                    {
-                                                        "type": "record",
-                                                        "name": "MetaData",
-                                                        "fields": [
-                                                            {
-                                                                "name": "Nonce",
-                                                                "type": "long"
-                                                            },
-                                                            {
-                                                                "name": "Name",
-                                                                "type": "string"
-                                                            },
-                                                            {
-                                                                "name": "Creator",
-                                                                "type": {
-                                                                    "type": "fixed",
-                                                                    "size": 62,
-                                                                    "name": "address"
-                                                                }
-                                                            },
-                                                            {
-                                                                "name": "Royalties",
-                                                                "type": "int"
-                                                            },
-                                                            {
-                                                                "name": "Hash",
-                                                                "type": "bytes"
-                                                            },
-                                                            {
-                                                                "name": "URIs",
-                                                                "type": {
-                                                                    "type": "array",
-                                                                    "items": "bytes"
-                                                                }
-                                                            },
-                                                            {
-                                                                "name": "Attributes",
-                                                                "type": "bytes"
-                                                            }
-                                                        ]
-                                                    }
-                                                ]
                                             }
                                         ]
                                     }
@@ -1294,54 +1171,6 @@ var _AccountBalanceUpdate_schema, _AccountBalanceUpdate_schema_err = avro.ParseS
                             {
                                 "name": "Properties",
                                 "type": "string"
-                            },
-                            {
-                                "name": "MetaData",
-                                "default": null,
-                                "type": [
-                                    "null",
-                                    {
-                                        "type": "record",
-                                        "name": "MetaData",
-                                        "fields": [
-                                            {
-                                                "name": "Nonce",
-                                                "type": "long"
-                                            },
-                                            {
-                                                "name": "Name",
-                                                "type": "string"
-                                            },
-                                            {
-                                                "name": "Creator",
-                                                "type": {
-                                                    "type": "fixed",
-                                                    "size": 62,
-                                                    "name": "address"
-                                                }
-                                            },
-                                            {
-                                                "name": "Royalties",
-                                                "type": "int"
-                                            },
-                                            {
-                                                "name": "Hash",
-                                                "type": "bytes"
-                                            },
-                                            {
-                                                "name": "URIs",
-                                                "type": {
-                                                    "type": "array",
-                                                    "items": "bytes"
-                                                }
-                                            },
-                                            {
-                                                "name": "Attributes",
-                                                "type": "bytes"
-                                            }
-                                        ]
-                                    }
-                                ]
                             }
                         ]
                     }
@@ -1371,97 +1200,6 @@ var _AccountTokenData_schema, _AccountTokenData_schema_err = avro.ParseSchema(`{
         {
             "name": "Properties",
             "type": "string"
-        },
-        {
-            "name": "MetaData",
-            "default": null,
-            "type": [
-                "null",
-                {
-                    "type": "record",
-                    "name": "MetaData",
-                    "fields": [
-                        {
-                            "name": "Nonce",
-                            "type": "long"
-                        },
-                        {
-                            "name": "Name",
-                            "type": "string"
-                        },
-                        {
-                            "name": "Creator",
-                            "type": {
-                                "type": "fixed",
-                                "size": 62,
-                                "name": "address"
-                            }
-                        },
-                        {
-                            "name": "Royalties",
-                            "type": "int"
-                        },
-                        {
-                            "name": "Hash",
-                            "type": "bytes"
-                        },
-                        {
-                            "name": "URIs",
-                            "type": {
-                                "type": "array",
-                                "items": "bytes"
-                            }
-                        },
-                        {
-                            "name": "Attributes",
-                            "type": "bytes"
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
-}`)
-
-// Generated by codegen. Please do not modify.
-var _MetaData_schema, _MetaData_schema_err = avro.ParseSchema(`{
-    "type": "record",
-    "name": "MetaData",
-    "fields": [
-        {
-            "name": "Nonce",
-            "type": "long"
-        },
-        {
-            "name": "Name",
-            "type": "string"
-        },
-        {
-            "name": "Creator",
-            "type": {
-                "type": "fixed",
-                "size": 62,
-                "name": "address"
-            }
-        },
-        {
-            "name": "Royalties",
-            "type": "int"
-        },
-        {
-            "name": "Hash",
-            "type": "bytes"
-        },
-        {
-            "name": "URIs",
-            "type": {
-                "type": "array",
-                "items": "bytes"
-            }
-        },
-        {
-            "name": "Attributes",
-            "type": "bytes"
         }
     ]
 }`)


### PR DESCRIPTION
Removed `MetaData` from api responses, since it could not be consistently provided.
This information is also available from logs, at each `NFTCreate` builtin function call.