### PR TITLE
Add support for hyper blocks queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ for historical balances (--operation-mode historical-balances when starting the 
 
 - `/hyperblock/by-nonce/:nonce` (GET) --> returns a hyperblock by nonce, with transactions included
 - `/hyperblock/by-hash/:hash` (GET) --> returns a hyperblock by hash, with transactions included
+- `/hyperblocks?startNonce=4&endNonce=8` (GET) --> returns an array of encoded hyperblocks in `[startNonce, endNonce]` interval
 
 ## Avro schema update
 

--- a/api/dtos.go
+++ b/api/dtos.go
@@ -34,3 +34,10 @@ type CovalentHyperBlockApiResponse struct {
 	Error string     `json:"error"`
 	Code  ReturnCode `json:"code"`
 }
+
+// CovalentHyperBlocksApiResponse is the hyper blocks dto response for Covalent
+type CovalentHyperBlocksApiResponse struct {
+	Data  [][]byte   `json:"data"`
+	Error string     `json:"error"`
+	Code  ReturnCode `json:"code"`
+}

--- a/api/errors.go
+++ b/api/errors.go
@@ -9,3 +9,7 @@ var errNilHyperBlockFacade = errors.New("nil hyper block facade provided")
 var errInvalidBlockNonce = errors.New("invalid block nonce")
 
 var errInvalidBlockHash = errors.New("invalid block hash")
+
+var errInvalidHyperBlocksBatchSize = errors.New("invalid hyper blocks batch size")
+
+var errMissingQueryParameter = errors.New("missing query parameter")

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -8,6 +8,10 @@ var ErrNilHyperBlockFacade = errNilHyperBlockFacade
 
 var ErrInvalidBlockNonce = errInvalidBlockNonce
 
+var ErrInvalidHyperBlocksBatchSize = errInvalidHyperBlocksBatchSize
+
+var ErrMissingQueryParameter = errMissingQueryParameter
+
 func GetNonceFromRequest(c *gin.Context) (uint64, error) {
 	return getNonceFromRequest(c)
 }

--- a/api/hyper_block_proxy.go
+++ b/api/hyper_block_proxy.go
@@ -13,13 +13,14 @@ import (
 type hyperBlockProxy struct {
 	hyperBlockFacade HyperBlockFacadeHandler
 	options          config.HyperBlockQueryOptions
+	batchSize        uint32
 }
 
 // NewHyperBlockProxy will create a covalent proxy, able to fetch hyper block requests
 // from Elrond and return them in covalent format
 func NewHyperBlockProxy(
 	hyperBlockFacade HyperBlockFacadeHandler,
-	hyperBlockQueryOptions config.HyperBlockQueryOptions,
+	cfg *config.Config,
 ) (*hyperBlockProxy, error) {
 	if hyperBlockFacade == nil {
 		return nil, errNilHyperBlockFacade
@@ -27,7 +28,8 @@ func NewHyperBlockProxy(
 
 	return &hyperBlockProxy{
 		hyperBlockFacade: hyperBlockFacade,
-		options:          hyperBlockQueryOptions,
+		options:          cfg.HyperBlockQueryOptions,
+		batchSize:        cfg.HyperBlocksBatchSize,
 	}, nil
 }
 
@@ -57,7 +59,7 @@ func getNonceFromRequest(c *gin.Context) (uint64, error) {
 	return strconv.ParseUint(nonceStr, 10, 64)
 }
 
-// GetHyperBlocksByNonce will fetch requested hyper blocks from start to end nonce
+// GetHyperBlocksByInterval will fetch requested hyper blocks from start to end nonce
 func (hbp *hyperBlockProxy) GetHyperBlocksByInterval(c *gin.Context) {
 	nonceInterval, err := getIntervalFromRequest(c)
 	if err != nil {

--- a/api/hyper_block_proxy.go
+++ b/api/hyper_block_proxy.go
@@ -25,7 +25,7 @@ type hyperBlockProxy struct {
 // from Elrond and return them in covalent format
 func NewHyperBlockProxy(
 	hyperBlockFacade HyperBlockFacadeHandler,
-	cfg *config.Config,
+	cfg config.Config,
 ) (*hyperBlockProxy, error) {
 	if hyperBlockFacade == nil {
 		return nil, errNilHyperBlockFacade

--- a/api/hyper_block_proxy_test.go
+++ b/api/hyper_block_proxy_test.go
@@ -65,7 +65,7 @@ func sendRequest(t *testing.T, ws *gin.Engine, path string, expectedStatus int) 
 	return apiResp
 }
 
-func sendRequestHyperBlocks(t *testing.T, ws *gin.Engine, path string, expectedStatus int) *api.CovalentHyperBlocksApiResponse {
+func sendHyperBlocksRequest(t *testing.T, ws *gin.Engine, path string, expectedStatus int) *api.CovalentHyperBlocksApiResponse {
 	body := serveHTTPRequest(t, ws, path, expectedStatus)
 
 	apiResp := &api.CovalentHyperBlocksApiResponse{}
@@ -220,7 +220,7 @@ func TestHyperBlockProxy_GetHyperBlocksByInterval(t *testing.T) {
 		ws := startProxyServer(proxy)
 		requestPath := fmt.Sprintf("%s?startNonce=%d&endNonce=%d", hyperBlocksPath, startNonce, endNonce)
 
-		apiResp := sendRequestHyperBlocks(t, ws, requestPath, http.StatusOK)
+		apiResp := sendHyperBlocksRequest(t, ws, requestPath, http.StatusOK)
 		require.Equal(t, apiResp, blockResponse)
 	})
 
@@ -238,7 +238,7 @@ func TestHyperBlockProxy_GetHyperBlocksByInterval(t *testing.T) {
 		ws := startProxyServer(proxy)
 
 		requestPath := fmt.Sprintf("%s?startNonce=abc&endNonce=8", hyperBlocksPath)
-		apiResp := sendRequestHyperBlocks(t, ws, requestPath, http.StatusBadRequest)
+		apiResp := sendHyperBlocksRequest(t, ws, requestPath, http.StatusBadRequest)
 		require.False(t, getHyperBlockFromFacadeCalled)
 		require.Empty(t, apiResp.Data)
 		require.Equal(t, apiResp.Code, api.ReturnCodeRequestError)
@@ -259,7 +259,7 @@ func TestHyperBlockProxy_GetHyperBlocksByInterval(t *testing.T) {
 		ws := startProxyServer(proxy)
 
 		requestPath := fmt.Sprintf("%s?startNonce=4&endNonce=cde", hyperBlocksPath)
-		apiResp := sendRequestHyperBlocks(t, ws, requestPath, http.StatusBadRequest)
+		apiResp := sendHyperBlocksRequest(t, ws, requestPath, http.StatusBadRequest)
 		require.False(t, getHyperBlockFromFacadeCalled)
 		require.Empty(t, apiResp.Data)
 		require.Equal(t, apiResp.Code, api.ReturnCodeRequestError)
@@ -280,7 +280,7 @@ func TestHyperBlockProxy_GetHyperBlocksByInterval(t *testing.T) {
 		ws := startProxyServer(proxy)
 
 		requestPath := fmt.Sprintf("%s?startNonce=4", hyperBlocksPath)
-		apiResp := sendRequestHyperBlocks(t, ws, requestPath, http.StatusBadRequest)
+		apiResp := sendHyperBlocksRequest(t, ws, requestPath, http.StatusBadRequest)
 		require.False(t, getHyperBlockFromFacadeCalled)
 		require.Empty(t, apiResp.Data)
 		require.Equal(t, apiResp.Code, api.ReturnCodeRequestError)
@@ -301,7 +301,7 @@ func TestHyperBlockProxy_GetHyperBlocksByInterval(t *testing.T) {
 		ws := startProxyServer(proxy)
 
 		requestPath := fmt.Sprintf("%s?startNonce=4&endNonce=8", hyperBlocksPath)
-		apiResp := sendRequestHyperBlocks(t, ws, requestPath, http.StatusInternalServerError)
+		apiResp := sendHyperBlocksRequest(t, ws, requestPath, http.StatusInternalServerError)
 		require.Equal(t, &api.CovalentHyperBlocksApiResponse{
 			Data:  nil,
 			Error: errFacade.Error(),

--- a/api/hyper_block_proxy_test.go
+++ b/api/hyper_block_proxy_test.go
@@ -74,8 +74,8 @@ func sendHyperBlocksRequest(t *testing.T, ws *gin.Engine, path string, expectedS
 	return apiResp
 }
 
-func getConfig() *config.Config {
-	return &config.Config{
+func getConfig() config.Config {
+	return config.Config{
 		HyperBlocksBatchSize: 10,
 	}
 }
@@ -102,7 +102,7 @@ func TestNewHyperBlockProxy(t *testing.T) {
 	t.Run("invalid hyper blocks batch size, should return error", func(t *testing.T) {
 		t.Parallel()
 
-		proxy, err := api.NewHyperBlockProxy(&apiMocks.HyperBlockFacadeStub{}, &config.Config{})
+		proxy, err := api.NewHyperBlockProxy(&apiMocks.HyperBlockFacadeStub{}, config.Config{})
 		require.Nil(t, proxy)
 		require.ErrorIs(t, err, api.ErrInvalidHyperBlocksBatchSize)
 	})

--- a/api/hyper_block_proxy_test.go
+++ b/api/hyper_block_proxy_test.go
@@ -59,7 +59,7 @@ func TestNewHyperBlockProxy(t *testing.T) {
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		proxy, err := api.NewHyperBlockProxy(&apiMocks.HyperBlockFacadeStub{}, config.HyperBlockQueryOptions{})
+		proxy, err := api.NewHyperBlockProxy(&apiMocks.HyperBlockFacadeStub{}, &config.Config{})
 		require.Nil(t, err)
 		require.NotNil(t, proxy)
 	})
@@ -67,7 +67,7 @@ func TestNewHyperBlockProxy(t *testing.T) {
 	t.Run("nil facade, should return error", func(t *testing.T) {
 		t.Parallel()
 
-		proxy, err := api.NewHyperBlockProxy(nil, config.HyperBlockQueryOptions{})
+		proxy, err := api.NewHyperBlockProxy(nil, &config.Config{})
 		require.Nil(t, proxy)
 		require.Equal(t, api.ErrNilHyperBlockFacade, err)
 	})
@@ -108,7 +108,7 @@ func TestHyperBlockProxy_GetHyperBlockByNonce(t *testing.T) {
 				return blockResponse, nil
 			},
 		}
-		proxy, _ := api.NewHyperBlockProxy(facade, config.HyperBlockQueryOptions{})
+		proxy, _ := api.NewHyperBlockProxy(facade, &config.Config{})
 		ws := startProxyServer(proxy)
 		requestPath := fmt.Sprintf("%s/by-nonce/%d", hyperBlockPath, requestedNonce)
 		apiResp := sendRequest(t, ws, requestPath, http.StatusOK)
@@ -125,7 +125,7 @@ func TestHyperBlockProxy_GetHyperBlockByNonce(t *testing.T) {
 				return nil, nil
 			},
 		}
-		proxy, _ := api.NewHyperBlockProxy(facade, config.HyperBlockQueryOptions{})
+		proxy, _ := api.NewHyperBlockProxy(facade, &config.Config{})
 		ws := startProxyServer(proxy)
 
 		requestPath := fmt.Sprintf("%s/by-nonce/abc", hyperBlockPath)
@@ -145,7 +145,7 @@ func TestHyperBlockProxy_GetHyperBlockByNonce(t *testing.T) {
 				return nil, errFacade
 			},
 		}
-		proxy, _ := api.NewHyperBlockProxy(facade, config.HyperBlockQueryOptions{})
+		proxy, _ := api.NewHyperBlockProxy(facade, &config.Config{})
 		ws := startProxyServer(proxy)
 
 		requestPath := fmt.Sprintf("%s/by-nonce/4", hyperBlockPath)
@@ -176,7 +176,7 @@ func TestHyperBlockProxy_GetHyperBlockByHash(t *testing.T) {
 				return blockResponse, nil
 			},
 		}
-		proxy, _ := api.NewHyperBlockProxy(facade, config.HyperBlockQueryOptions{})
+		proxy, _ := api.NewHyperBlockProxy(facade, &config.Config{})
 		ws := startProxyServer(proxy)
 		requestPath := fmt.Sprintf("%s/by-hash/%s", hyperBlockPath, requestedHash)
 		apiResp := sendRequest(t, ws, requestPath, http.StatusOK)
@@ -193,7 +193,7 @@ func TestHyperBlockProxy_GetHyperBlockByHash(t *testing.T) {
 				return nil, nil
 			},
 		}
-		proxy, _ := api.NewHyperBlockProxy(facade, config.HyperBlockQueryOptions{})
+		proxy, _ := api.NewHyperBlockProxy(facade, &config.Config{})
 		ws := startProxyServer(proxy)
 
 		requestPath := fmt.Sprintf("%s/by-hash/zx", hyperBlockPath)
@@ -213,7 +213,7 @@ func TestHyperBlockProxy_GetHyperBlockByHash(t *testing.T) {
 				return nil, errFacade
 			},
 		}
-		proxy, _ := api.NewHyperBlockProxy(facade, config.HyperBlockQueryOptions{})
+		proxy, _ := api.NewHyperBlockProxy(facade, &config.Config{})
 		ws := startProxyServer(proxy)
 
 		requestPath := fmt.Sprintf("%s/by-hash/ff", hyperBlockPath)

--- a/api/interface.go
+++ b/api/interface.go
@@ -29,6 +29,7 @@ type ElrondHyperBlockEndpointHandler interface {
 type HyperBlockFacadeHandler interface {
 	GetHyperBlockByNonce(nonce uint64, options config.HyperBlockQueryOptions) (*CovalentHyperBlockApiResponse, error)
 	GetHyperBlockByHash(hash string, options config.HyperBlockQueryOptions) (*CovalentHyperBlockApiResponse, error)
+	GetHyperBlocksByInterval(noncesInterval *Interval, options config.HyperBlockQueryOptions) (*CovalentHyperBlockApiResponse, error)
 }
 
 // HyperBlockProxy is the covalent proxy. It should be able to fetch hyper blocks from
@@ -36,4 +37,5 @@ type HyperBlockFacadeHandler interface {
 type HyperBlockProxy interface {
 	GetHyperBlockByNonce(c *gin.Context)
 	GetHyperBlockByHash(c *gin.Context)
+	GetHyperBlocksByInterval(c *gin.Context)
 }

--- a/api/interface.go
+++ b/api/interface.go
@@ -29,7 +29,7 @@ type ElrondHyperBlockEndpointHandler interface {
 type HyperBlockFacadeHandler interface {
 	GetHyperBlockByNonce(nonce uint64, options config.HyperBlockQueryOptions) (*CovalentHyperBlockApiResponse, error)
 	GetHyperBlockByHash(hash string, options config.HyperBlockQueryOptions) (*CovalentHyperBlockApiResponse, error)
-	GetHyperBlocksByInterval(noncesInterval *Interval, options config.HyperBlockQueryOptions) (*CovalentHyperBlockApiResponse, error)
+	GetHyperBlocksByInterval(noncesInterval *Interval, options config.HyperBlockQueryOptions) (*CovalentHyperBlocksApiResponse, error)
 }
 
 // HyperBlockProxy is the covalent proxy. It should be able to fetch hyper blocks from

--- a/api/options.go
+++ b/api/options.go
@@ -10,3 +10,9 @@ const (
 	// UrlParameterTokens represents the name of an URL parameter to query altered accounts with tokens
 	UrlParameterTokens = "tokens"
 )
+
+// Interval defines a [start,end] interval
+type Interval struct {
+	Start uint64
+	End   uint64
+}

--- a/cmd/proxy/config.toml
+++ b/cmd/proxy/config.toml
@@ -7,7 +7,7 @@ hyperBlockPath = "/hyperblock"
 # API path to get hyperBlocks from covalent proxy
 hyperBlocksPath = "/hyperblocks"
 
-# When fetching multiple hyperblocks, requests will be parallelized in hyperBlocksBatchSize
+# When fetching multiple hyperblocks, requests will be grouped in hyperBlocksBatchSize and parallelized
 hyperBlocksBatchSize = 10
 
 # elrondProxyUrl url used to fetch hyperBlocks from Elrond; e.g.: https://gateway.elrond.com for mainnet

--- a/cmd/proxy/config.toml
+++ b/cmd/proxy/config.toml
@@ -7,6 +7,9 @@ hyperBlockPath = "/hyperblock"
 # API path to get hyperBlocks from covalent proxy
 hyperBlocksPath = "/hyperblocks"
 
+# When fetching multiple hyperblocks, requests will be parallelized in hyperBlocksBatchSize
+hyperBlocksBatchSize = 10
+
 # elrondProxyUrl url used to fetch hyperBlocks from Elrond; e.g.: https://gateway.elrond.com for mainnet
 elrondProxyUrl = "https://gateway.elrond.com"
 

--- a/cmd/proxy/config.toml
+++ b/cmd/proxy/config.toml
@@ -4,6 +4,9 @@ port = 8086
 # API path to get hyperBlock from covalent proxy
 hyperBlockPath = "/hyperblock"
 
+# API path to get hyperBlocks from covalent proxy
+hyperBlocksPath = "/hyperblocks"
+
 # elrondProxyUrl url used to fetch hyperBlocks from Elrond; e.g.: https://gateway.elrond.com for mainnet
 elrondProxyUrl = "https://gateway.elrond.com"
 

--- a/cmd/proxy/config/config.go
+++ b/cmd/proxy/config/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	Port                   uint32                 `toml:"port"`
 	HyperBlockPath         string                 `toml:"hyperBlockPath"`
+	HyperBlocksPath        string                 `toml:"hyperBlocksPath"`
 	ElrondProxyUrl         string                 `toml:"elrondProxyUrl"`
 	RequestTimeOutSec      uint64                 `toml:"requestTimeOutSec"`
 	HyperBlockQueryOptions HyperBlockQueryOptions `toml:"hyperBlockQueryOptions"`

--- a/cmd/proxy/config/config.go
+++ b/cmd/proxy/config/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	Port                   uint32                 `toml:"port"`
 	HyperBlockPath         string                 `toml:"hyperBlockPath"`
 	HyperBlocksPath        string                 `toml:"hyperBlocksPath"`
+	HyperBlocksBatchSize   uint32                 `toml:"hyperBlocksBatchSize"`
 	ElrondProxyUrl         string                 `toml:"elrondProxyUrl"`
 	RequestTimeOutSec      uint64                 `toml:"requestTimeOutSec"`
 	HyperBlockQueryOptions HyperBlockQueryOptions `toml:"hyperBlockQueryOptions"`

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -94,7 +94,7 @@ func createServer(cfg *config.Config) (api.HTTPServer, error) {
 		return nil, err
 	}
 
-	hyperBlockProxy, err := api.NewHyperBlockProxy(hyperBlockFacade, cfg)
+	hyperBlockProxy, err := api.NewHyperBlockProxy(hyperBlockFacade, *cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -94,7 +94,7 @@ func createServer(cfg *config.Config) (api.HTTPServer, error) {
 		return nil, err
 	}
 
-	hyperBlockProxy, err := api.NewHyperBlockProxy(hyperBlockFacade, cfg.HyperBlockQueryOptions)
+	hyperBlockProxy, err := api.NewHyperBlockProxy(hyperBlockFacade, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -100,6 +100,7 @@ func createServer(cfg *config.Config) (api.HTTPServer, error) {
 	}
 
 	router := gin.Default()
+	router.GET(fmt.Sprintf("%s", cfg.HyperBlocksPath), hyperBlockProxy.GetHyperBlocksByInterval)
 	router.GET(fmt.Sprintf("%s/by-nonce/:nonce", cfg.HyperBlockPath), hyperBlockProxy.GetHyperBlockByNonce)
 	router.GET(fmt.Sprintf("%s/by-hash/:hash", cfg.HyperBlockPath), hyperBlockProxy.GetHyperBlockByHash)
 

--- a/facade/errors.go
+++ b/facade/errors.go
@@ -9,3 +9,5 @@ var errNilAvroEncoder = errors.New("nil avro encoder provided")
 var errNilHyperBlockProcessor = errors.New("nil hyper block processor provided")
 
 var errNilHyperBlockEndpointHandler = errors.New("nil hyper block endpoint handler provided")
+
+var errInvalidNoncesInterval = errors.New("invalid nonces interval")

--- a/facade/hyper_block_facade.go
+++ b/facade/hyper_block_facade.go
@@ -48,13 +48,13 @@ func NewHyperBlockFacade(
 }
 
 // GetHyperBlockByNonce will fetch the hyper block from Elrond proxy with provided nonce and options in covalent format
-func (hpf *hyperBlockFacade) GetHyperBlockByNonce(nonce uint64, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
-	fullPath := hpf.getHyperBlockByNonceFullPath(nonce, options)
-	return hpf.getHyperBlock(fullPath)
+func (hbf *hyperBlockFacade) GetHyperBlockByNonce(nonce uint64, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
+	fullPath := hbf.getHyperBlockByNonceFullPath(nonce, options)
+	return hbf.getHyperBlock(fullPath)
 }
 
 // GetHyperBlocksByInterval will fetch the hyper blocks from Elrond proxy with provided nonces interval and options in covalent format
-func (hpf *hyperBlockFacade) GetHyperBlocksByInterval(noncesInterval *api.Interval, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlocksApiResponse, error) {
+func (hbf *hyperBlockFacade) GetHyperBlocksByInterval(noncesInterval *api.Interval, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlocksApiResponse, error) {
 	if noncesInterval.Start > noncesInterval.End {
 		return nil, errInvalidNoncesInterval
 	}
@@ -62,8 +62,8 @@ func (hpf *hyperBlockFacade) GetHyperBlocksByInterval(noncesInterval *api.Interv
 	// Dummy implementation with no parallel bulk requests. This implementation will follow in next PR
 	encodedHyperBlocks := make([][]byte, 0, noncesInterval.End-noncesInterval.Start)
 	for nonce := noncesInterval.Start; nonce <= noncesInterval.End; nonce++ {
-		fullPath := hpf.getHyperBlockByNonceFullPath(nonce, options)
-		encodedHyperBlock, err := hpf.getHyperBlockAvroBytes(fullPath)
+		fullPath := hbf.getHyperBlockByNonceFullPath(nonce, options)
+		encodedHyperBlock, err := hbf.getHyperBlockAvroBytes(fullPath)
 		if err != nil {
 			return nil, err
 		}
@@ -78,14 +78,14 @@ func (hpf *hyperBlockFacade) GetHyperBlocksByInterval(noncesInterval *api.Interv
 	}, nil
 }
 
-func (hpf *hyperBlockFacade) getHyperBlockByNonceFullPath(nonce uint64, options config.HyperBlockQueryOptions) string {
+func (hbf *hyperBlockFacade) getHyperBlockByNonceFullPath(nonce uint64, options config.HyperBlockQueryOptions) string {
 	blockByNoncePath := fmt.Sprintf("%s/%d", hyperBlockPathByNonce, nonce)
-	return hpf.getFullPathWithOptions(blockByNoncePath, options)
+	return hbf.getFullPathWithOptions(blockByNoncePath, options)
 }
 
-func (hpf *hyperBlockFacade) getFullPathWithOptions(path string, options config.HyperBlockQueryOptions) string {
+func (hbf *hyperBlockFacade) getFullPathWithOptions(path string, options config.HyperBlockQueryOptions) string {
 	pathWithOptions := buildUrlWithBlockQueryOptions(path, options)
-	return fmt.Sprintf("%s%s", hpf.elrondProxyUrl, pathWithOptions)
+	return fmt.Sprintf("%s%s", hbf.elrondProxyUrl, pathWithOptions)
 }
 
 func buildUrlWithBlockQueryOptions(path string, options config.HyperBlockQueryOptions) string {
@@ -113,22 +113,22 @@ func setQueryParamIfNotEmpty(query url.Values, option string, urlParam string) {
 	}
 }
 
-func (hpf *hyperBlockFacade) getHyperBlockAvroBytes(path string) ([]byte, error) {
-	elrondHyperBlock, err := hpf.elrondEndpoint.GetHyperBlock(path)
+func (hbf *hyperBlockFacade) getHyperBlockAvroBytes(path string) ([]byte, error) {
+	elrondHyperBlock, err := hbf.elrondEndpoint.GetHyperBlock(path)
 	if err != nil {
 		return nil, err
 	}
 
-	hyperBlockSchema, err := hpf.processor.Process(&elrondHyperBlock.Data.HyperBlock)
+	hyperBlockSchema, err := hbf.processor.Process(&elrondHyperBlock.Data.HyperBlock)
 	if err != nil {
 		return nil, err
 	}
 
-	return hpf.encoder.Encode(hyperBlockSchema)
+	return hbf.encoder.Encode(hyperBlockSchema)
 }
 
-func (hpf *hyperBlockFacade) getHyperBlock(path string) (*api.CovalentHyperBlockApiResponse, error) {
-	hyperBlockSchemaAvroBytes, err := hpf.getHyperBlockAvroBytes(path)
+func (hbf *hyperBlockFacade) getHyperBlock(path string) (*api.CovalentHyperBlockApiResponse, error) {
+	hyperBlockSchemaAvroBytes, err := hbf.getHyperBlockAvroBytes(path)
 	if err != nil {
 		return nil, err
 	}
@@ -141,9 +141,9 @@ func (hpf *hyperBlockFacade) getHyperBlock(path string) (*api.CovalentHyperBlock
 }
 
 // GetHyperBlockByHash will fetch the hyper block from Elrond proxy with provided hash and options in covalent format
-func (hpf *hyperBlockFacade) GetHyperBlockByHash(hash string, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
+func (hbf *hyperBlockFacade) GetHyperBlockByHash(hash string, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
 	blockByHashPath := fmt.Sprintf("%s/%s", hyperBlockPathByHash, hash)
-	fullPath := hpf.getFullPathWithOptions(blockByHashPath, options)
+	fullPath := hbf.getFullPathWithOptions(blockByHashPath, options)
 
-	return hpf.getHyperBlock(fullPath)
+	return hbf.getHyperBlock(fullPath)
 }

--- a/facade/hyper_block_facade.go
+++ b/facade/hyper_block_facade.go
@@ -55,6 +55,14 @@ func (hpf *hyperBlockFacade) GetHyperBlockByNonce(nonce uint64, options config.H
 	return hpf.getHyperBlock(fullPath)
 }
 
+// GetHyperBlocksByInterval will fetch the hyper blocks from Elrond proxy with provided nonces interval and options in covalent format
+func (hpf *hyperBlockFacade) GetHyperBlocksByInterval(noncesInterval *api.Interval, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
+	blockByNoncePath := fmt.Sprintf("%s/%d", hyperBlockPathByNonce, noncesInterval.Start)
+	fullPath := hpf.getFullPathWithOptions(blockByNoncePath, options)
+
+	return hpf.getHyperBlock(fullPath)
+}
+
 // GetHyperBlockByHash will fetch the hyper block from Elrond proxy with provided hash and options in covalent format
 func (hpf *hyperBlockFacade) GetHyperBlockByHash(hash string, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
 	blockByHashPath := fmt.Sprintf("%s/%s", hyperBlockPathByHash, hash)

--- a/facade/hyper_block_facade.go
+++ b/facade/hyper_block_facade.go
@@ -60,7 +60,7 @@ func (hbf *hyperBlockFacade) GetHyperBlocksByInterval(noncesInterval *api.Interv
 	}
 
 	// Dummy implementation with no parallel bulk requests. This implementation will follow in next PR
-	encodedHyperBlocks := make([][]byte, 0, noncesInterval.End-noncesInterval.Start)
+	encodedHyperBlocks := make([][]byte, 0, noncesInterval.End-noncesInterval.Start+1)
 	for nonce := noncesInterval.Start; nonce <= noncesInterval.End; nonce++ {
 		fullPath := hbf.getHyperBlockByNonceFullPath(nonce, options)
 		encodedHyperBlock, err := hbf.getHyperBlockAvroBytes(fullPath)

--- a/testscommon/mock/apiMocks/hyper_block_facade_stub.go
+++ b/testscommon/mock/apiMocks/hyper_block_facade_stub.go
@@ -7,8 +7,9 @@ import (
 
 // HyperBlockFacadeStub -
 type HyperBlockFacadeStub struct {
-	GetHyperBlockByNonceCalled func(nonce uint64, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error)
-	GetHyperBlockByHashCalled  func(hash string, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error)
+	GetHyperBlockByNonceCalled     func(nonce uint64, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error)
+	GetHyperBlockByHashCalled      func(hash string, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error)
+	GetHyperBlocksByIntervalCalled func(noncesInterval *api.Interval, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error)
 }
 
 // GetHyperBlockByNonce -
@@ -24,6 +25,14 @@ func (hbf *HyperBlockFacadeStub) GetHyperBlockByNonce(nonce uint64, options conf
 func (hbf *HyperBlockFacadeStub) GetHyperBlockByHash(hash string, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
 	if hbf.GetHyperBlockByHashCalled != nil {
 		return hbf.GetHyperBlockByHashCalled(hash, options)
+	}
+
+	return nil, nil
+}
+
+func (hbf *HyperBlockFacadeStub) GetHyperBlocksByInterval(noncesInterval *api.Interval, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
+	if hbf.GetHyperBlocksByIntervalCalled != nil {
+		return hbf.GetHyperBlocksByIntervalCalled(noncesInterval, options)
 	}
 
 	return nil, nil

--- a/testscommon/mock/apiMocks/hyper_block_facade_stub.go
+++ b/testscommon/mock/apiMocks/hyper_block_facade_stub.go
@@ -9,7 +9,7 @@ import (
 type HyperBlockFacadeStub struct {
 	GetHyperBlockByNonceCalled     func(nonce uint64, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error)
 	GetHyperBlockByHashCalled      func(hash string, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error)
-	GetHyperBlocksByIntervalCalled func(noncesInterval *api.Interval, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error)
+	GetHyperBlocksByIntervalCalled func(noncesInterval *api.Interval, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlocksApiResponse, error)
 }
 
 // GetHyperBlockByNonce -
@@ -30,7 +30,7 @@ func (hbf *HyperBlockFacadeStub) GetHyperBlockByHash(hash string, options config
 	return nil, nil
 }
 
-func (hbf *HyperBlockFacadeStub) GetHyperBlocksByInterval(noncesInterval *api.Interval, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlockApiResponse, error) {
+func (hbf *HyperBlockFacadeStub) GetHyperBlocksByInterval(noncesInterval *api.Interval, options config.HyperBlockQueryOptions) (*api.CovalentHyperBlocksApiResponse, error) {
 	if hbf.GetHyperBlocksByIntervalCalled != nil {
 		return hbf.GetHyperBlocksByIntervalCalled(noncesInterval, options)
 	}


### PR DESCRIPTION
- Added support for `hyperBlocks` queries. In order to query multiple hyperBlocks, `startNonce` and `endNonce` parameters should be provided, e.g. `http://127.0.0.1:8086/hyperblocks?startNonce=4&endNonce=8` 
- New `CovalentHyperBlocksApiResponse` will simply contain a `Data [][]byte` field response, each corresponding to a nonce.
- For now, `GetHyperBlocksByInterval` from `hyperBlockFacade` only contains a dummy implementation. In a future PR, interval will be split in `hyperBlocksBatchSize` smaller intervals, which will be queried in parallel. 